### PR TITLE
[Fix] TypeError: a bytes-like object is required, not 'str'.

### DIFF
--- a/scapy_http/http.py
+++ b/scapy_http/http.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: UTF-8 -*-
 # Author : Steeve Barbeau, Luca Invernizzi
+# Author of the modifications: Jarosław Wieczorek 
 # This program is published under a GPLv2 license
 
 import re
@@ -15,11 +16,11 @@ def _canonicalize_header(name):
     return name.strip().lower()
 
 def _parse_headers(s):
-    headers = s.split("\r\n")
+    headers = s.split(b"\r\n")
     headers_found = {}
     for header_line in headers:
         try:
-            key, value = header_line.split(':', 1)
+            key, value = header_line.split(b':', 1)
         except:
             continue
         headers_found[_canonicalize_header(key)] = header_line.strip()
@@ -38,7 +39,7 @@ def _parse_headers_and_body(s):
     except:
         headers = s
         body = ''
-    first_line, headers = headers.split("\r\n", 1)
+    first_line, headers = headers.split(b"\r\n", 1)
     return first_line.strip(), _parse_headers(headers), body
 
 
@@ -48,7 +49,7 @@ def _dissect_headers(obj, s):
         HTTP packet, and the body
     '''
     first_line, headers, body = _parse_headers_and_body(s)
-    obj.setfieldval('Headers', '\r\n'.join(list(headers.values())))
+    obj.setfieldval(b'Headers', b'\r\n'.join(list(headers.values())))
     for f in obj.fields_desc:
         canonical_name = _canonicalize_header(f.name)
         try:
@@ -61,7 +62,7 @@ def _dissect_headers(obj, s):
     if headers:
         # Kept for compatibility
         obj.setfieldval(
-            'Additional-Headers', '\r\n'.join(list(headers.values())) + '\r\n')
+            b'Additional-Headers', b'\r\n'.join(list(headers.values())) + '\r\n')
     return first_line, body
 
 


### PR DESCRIPTION
Deleted TypeError by changing the str on the b'str in the following lines (http.py):
``` bash
18c18
<     headers = s.split("\r\n")
---
>     headers = s.split(b"\r\n")
22c22
<             key, value = header_line.split(':', 1)
---
>             key, value = header_line.split(b':', 1)
41c41
<     first_line, headers = headers.split("\r\n", 1)
---
>     first_line, headers = headers.split(b"\r\n", 1)
51c51
<     obj.setfieldval('Headers', '\r\n'.join(list(headers.values())))
---
>     obj.setfieldval(b'Headers', b'\r\n'.join(list(headers.values())))
64c64
<             'Additional-Headers', '\r\n'.join(list(headers.values())) + '\r\n')
---
>             b'Additional-Headers', b'\r\n'.join(list(headers.values())) + '\r\n')



```